### PR TITLE
Add lazygit integration with --stdin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.14
+
+- Integration:
+  - Add `--stdin` option to read diff from stdin (for use as a pager in lazygit)
+  - Add README documentation for lazygit integration
+
 # 0.1.13
 
 - Docs:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ Then use:
 git difftool HEAD~1
 ```
 
+### Lazygit Integration
+
+Use critique as a custom pager in [lazygit](https://github.com/jesseduffield/lazygit):
+
+**As a pager (reads diff from stdin):**
+
+```yaml
+git:
+  pagers:
+    - pager: critique --stdin
+```
+
+**As an external diff command:**
+
+```yaml
+git:
+  pagers:
+    - externalDiffCommand: critique
+```
+
+For more details, see [lazygit's Custom Pagers documentation](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md).
+
 ### Pick Files from Another Branch
 
 Selectively apply changes from another branch to your current HEAD:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "critique",
   "module": "src/diff.tsx",
   "type": "module",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": false,
   "bin": "./src/cli.tsx",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR adds support for using critique as a custom pager in [lazygit](https://github.com/jesseduffield/lazygit), addressing issue #6.

## Changes

1. **New `--stdin` option** (`src/cli.tsx`):
   - Added ability to read diff from stdin instead of running git commands
   - Enables use as a pager in lazygit's configuration

2. **Documentation** (`README.md`):
   - Added "Lazygit Integration" section with configuration examples
   - Documented both pager mode (stdin) and external diff command modes

3. **Version bump** (`package.json`, `CHANGELOG.md`):
   - Bumped version to 0.1.14

## Usage

### As a pager (reads diff from stdin):

```yaml
git:
  pagers:
    - pager: critique --stdin
```

### As an external diff command:

```yaml
git:
  pagers:
    - externalDiffCommand: critique
```

For more details, see [lazygit's Custom Pagers documentation](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md).

## Testing

The `--stdin` option is available in the CLI help:
```
$ critique --help
Options:
  --stdin   Read diff from stdin (for use as a pager)
```

## Related

- Closes #6