### PR TITLE
fix: update @opentui/core-darwin-arm64 to 0.1.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.30
+
+- Dependencies:
+  - Update @opentui/core-darwin-arm64 to 0.1.73
+
 # 0.1.29
 
 - Web preview:

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@agentclientprotocol/sdk": "^0.12.0",
         "@clack/prompts": "1.0.0-alpha.9",
         "@opentui/core": "https://pkg.pr.new/anomalyco/opentui/@opentui/core@433",
+        "@opentui/core-darwin-arm64": "0.1.73",
         "@opentui/react": "https://pkg.pr.new/anomalyco/opentui/@opentui/react@433",
         "@parcel/watcher": "^2.5.1",
         "bun-pty": "^0.4.7",
@@ -228,7 +229,7 @@
 
     "@opentui/core": ["@opentui/core@https://pkg.pr.new/anomalyco/opentui/@opentui/core@433", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.72", "@opentui/core-darwin-x64": "0.1.72", "@opentui/core-linux-arm64": "0.1.72", "@opentui/core-linux-x64": "0.1.72", "@opentui/core-win32-arm64": "0.1.72", "@opentui/core-win32-x64": "0.1.72", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.72", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RoU48kOrhLZYDBiXaDu1LXS2bwRdlJlFle8eUQiqJjLRbMIY34J/srBuL0JnAS3qKW4J34NepUQa0l0/S43Q3w=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.73", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Xnc8S6kGIVcdwqqTq6jk50UVe1QtOXp+B0v4iH85iNW1Ljf198OoA7RcVA+edFb6o01PVwnhIIPtpkB/A4710w=="],
 
     "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.72", "", { "os": "darwin", "cpu": "x64" }, "sha512-hHUQw8i2LWPToRW1rjAiRqmNf34iJPS9ve9CJDygvFs5JOqUxN5yrfLfKfE+1bQjfFDHnpqW1HUk96iLhkPj8Q=="],
 
@@ -491,6 +492,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zustand": ["zustand@5.0.10", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg=="],
+
+    "@opentui/core/@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.72", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RoU48kOrhLZYDBiXaDu1LXS2bwRdlJlFle8eUQiqJjLRbMIY34J/srBuL0JnAS3qKW4J34NepUQa0l0/S43Q3w=="],
 
     "@opentui/core/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "critique",
   "module": "src/diff.tsx",
   "type": "module",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": false,
   "bin": "./src/cli.tsx",
   "scripts": {
@@ -25,6 +25,7 @@
     "@agentclientprotocol/sdk": "^0.12.0",
     "@clack/prompts": "1.0.0-alpha.9",
     "@opentui/core": "https://pkg.pr.new/anomalyco/opentui/@opentui/core@433",
+    "@opentui/core-darwin-arm64": "0.1.73",
     "@opentui/react": "https://pkg.pr.new/anomalyco/opentui/@opentui/react@433",
     "@parcel/watcher": "^2.5.1",
     "bun-pty": "^0.4.7",


### PR DESCRIPTION
## Summary
- Pins `@opentui/core-darwin-arm64` to v0.1.73 to fix FFI symbol mismatch with `@opentui/core` from PR #433
- Fixes `Symbol "getHitGridDirty" not found` error when running the CLI

## Context
The pre-release `@opentui/core` package from `pkg.pr.new` expects the `getHitGridDirty` symbol which was added in v0.1.73 of the native library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)