### PR TITLE
Add vim-style scroll navigation (G, gg, C-d, C-u)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.47
+
+- Add vim-style keyboard navigation:
+  - `G` (Shift+g) - scroll to bottom
+  - `gg` (double-tap g) - scroll to top
+  - `Ctrl+D` - half page down
+  - `Ctrl+U` - half page up
+- `review` command: change debug console toggle from `Ctrl+D` to `Ctrl+Z` (consistent with main viewer)
+
 # 0.1.46
 
 - Add directory tree view at top of diff TUIs (default, review, web commands)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "critique",
   "module": "src/diff.tsx",
   "type": "module",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": false,
   "bin": "./src/cli.tsx",
   "scripts": {


### PR DESCRIPTION
This adds a few vim scroll bindings. 

I know someone attempted this before and was closed, I think this more aligns with the approach you're taking with the tool. 

- `G` - jump to bottom
- `gg` - jump to top
- `Ctrl+D` - half page down
- `Ctrl+U` - half page up

These are pretty much muscle memory for anyone who uses vim. I noticed the Option key gives you fast scroll, but that's more for continuous scrolling. The half-page jumps are useful when you want to move in predictable chunks without overshooting.

No conflicts with existing keys - I specifically avoided `n`/`p` since those don't make sense anymore with the new scrollable view, and `p` is already taken by the file picker.

Tested on both the main diff view and the review app (however the review feature is still broken in this branch due to markdown component missing see #18 