### PR TITLE
Fix configuration syntax in README for lazygit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Use critique as a custom pager in [lazygit](https://github.com/jesseduffield/laz
 ```yaml
 # ~/.config/lazygit/config.yml
 git:
-  paging:
+  pagers:
     pager: critique --stdin
 ```
 


### PR DESCRIPTION
`pagers` is the proper option as per [docs](https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md) 